### PR TITLE
feat: add endpoint to list pending user feeds by ADMIN company

### DIFF
--- a/src/controllers/FeedController.js
+++ b/src/controllers/FeedController.js
@@ -3,6 +3,9 @@ const yup = require("yup");
 const UserCreateFeedService = require("../useCases/UserCreateFeedService");
 const userCreateFeedService = new UserCreateFeedService();
 
+const FeedListPendentService = require("../useCases/FeedListPendentService");
+const feedListPendentService = new FeedListPendentService();
+
 module.exports = {
   async createFeed(req, res, next) {
     try {
@@ -36,6 +39,20 @@ module.exports = {
       });
 
       return res.status(201).json({});
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async listFeedPendent(req, res, next) {
+    try {
+      const companyId = req.companyId;
+
+      const { page, pageSize } = req.query;
+
+      const results = await feedListPendentService.execute({companyId, page, pageSize});
+
+      res.json(results);
     } catch (err) {
       next(err);
     }

--- a/src/database/seeds/001_users.js
+++ b/src/database/seeds/001_users.js
@@ -23,5 +23,6 @@ exports.seed = async function(knex) {
   await knex('users').del()
   await knex('users').insert([
     {email: 'root@root.com', password: passwordHash, name: 'User 1', role_id: 1, company_id: 1},
+    {email: 'user@user.com', password: passwordHash, name: 'User 2', role_id: 2, company_id: 1}
   ]);
 };

--- a/src/middlewares/authorizeRole.js
+++ b/src/middlewares/authorizeRole.js
@@ -1,0 +1,10 @@
+module.exports = function authorizeRole(role) {
+  return (req, res, next) => {
+    if (req.role !== role.toUpperCase()) {
+      return res
+        .status(403)
+        .json({ message: "Sem permissão para realizar essa ação." });
+    }
+    next();
+  };
+};

--- a/src/repository/FeedRepository.js
+++ b/src/repository/FeedRepository.js
@@ -12,7 +12,37 @@ class FeedRepository {
   }
 
   findFeedByTitle(title) {
-    return knex("feeds").whereRaw("UPPER(title) = ?", [title.toUpperCase()]).limit(1);
+    return knex("feeds")
+      .whereRaw("UPPER(title) = ?", [title.toUpperCase()])
+      .limit(1);
+  }
+
+  getFeedIsPendentByCompanyId(params) {
+    let { companyId, page, pageSize } = params
+
+    if (page < 1) page = 1;
+
+    const offset = (page - 1) * pageSize;
+
+    return knex("feeds")
+      .select("feeds.*")
+      .limit(pageSize)
+      .offset(offset)
+      .innerJoin("users", "feeds.user_id", "=", "users.id")
+      .where("users.company_id", companyId)
+      .where("feeds.is_pendent", "=", true)
+      .orderBy("feeds.id", "desc")
+  }
+
+  getTotalFeedsIsPendentByCompanyId(params) {
+    let { companyId } = params
+
+
+    return knex("feeds")
+      .innerJoin("users", "feeds.user_id", "=", "users.id")
+      .where("users.company_id", companyId)
+      .where("feeds.is_pendent", "=", true)
+      .count("feeds.id");
   }
 }
 

--- a/src/routes/feedRoutes.js
+++ b/src/routes/feedRoutes.js
@@ -2,6 +2,7 @@ const express = require("express");
 const feedController = require("../controllers/FeedController");
 
 const hasAuthenticated = require("../middlewares/hasAuthenticated");
+const authorizeRole = require("../middlewares/authorizeRole");
 
 const multer = require("multer");
 
@@ -27,6 +28,13 @@ router.post(
   upload.single("image"),
   hasAuthenticated,
   feedController.createFeed
+);
+
+router.get(
+  "/feeds/pending",
+  hasAuthenticated,
+  authorizeRole("ADMIN"),
+  feedController.listFeedPendent
 );
 
 module.exports = router;

--- a/src/routes/inviteRoutes.js
+++ b/src/routes/inviteRoutes.js
@@ -1,20 +1,10 @@
 const express = require("express");
 const userController = require("../controllers/UsersController");
 
-const hasAuthenticated = require('../middlewares/hasAuthenticated');
+const hasAuthenticated = require("../middlewares/hasAuthenticated");
+const authorizeRole = require("../middlewares/authorizeRole");
 
 const router = express.Router();
-
-function authorizeRole(role) {
-  return (req, res, next) => {
-    if (req.role !== role.toUpperCase()) {
-      return res
-        .status(403)
-        .json({ message: "Sem permissão para realizar essa ação." });
-    }
-    next();
-  };
-}
 
 router.post(
   "/invite",
@@ -23,6 +13,6 @@ router.post(
   userController.inviteMember
 );
 
-router.put("/confirmation-invites/:hash", userController.confirmInvite)
+router.put("/confirmation-invites/:hash", userController.confirmInvite);
 
 module.exports = router;

--- a/src/useCases/FeedListPendentService.js
+++ b/src/useCases/FeedListPendentService.js
@@ -1,0 +1,29 @@
+const FeedRepository = require("../repository/FeedRepository");
+
+class FeedListPendentService {
+  constructor(feedRepository = new FeedRepository()) {
+    this.feedRepository = feedRepository;
+  }
+
+  async execute(params) {
+    const feedList = await this.feedRepository.getFeedIsPendentByCompanyId(
+      params
+    );
+
+    const countFeeds =
+      await this.feedRepository.getTotalFeedsIsPendentByCompanyId(params);
+
+    const total = countFeeds[0].count;
+
+    const result = {
+      total: total,
+      page: params.page,
+      pageSize: params.pageSize,
+      data: feedList,
+    };
+
+    return result;
+  }
+}
+
+module.exports = FeedListPendentService;

--- a/src/useCases/FeedListPendentService.spec.js
+++ b/src/useCases/FeedListPendentService.spec.js
@@ -1,0 +1,80 @@
+const FeedListPendentService = require("./FeedListPendentService");
+
+describe("FeedListPendentService", () => {
+  let feedListPendentService;
+
+  const params = {
+    companyId: 1,
+    page: 1,
+    pageSize: 10,
+  };
+
+  const feedRepository = {
+    getFeedIsPendentByCompanyId: jest.fn(),
+    getTotalFeedsIsPendentByCompanyId: jest.fn(),
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should handle empty feed list", async () => {
+    feedRepository.getFeedIsPendentByCompanyId.mockResolvedValue([]);
+
+    feedRepository.getTotalFeedsIsPendentByCompanyId.mockResolvedValue([
+      { count: 0 },
+    ]);
+
+    const result = {
+      total: 0,
+      page: params.page,
+      pageSize: params.pageSize,
+      data: [],
+    };
+
+    feedListPendentService = new FeedListPendentService(feedRepository);
+
+    const feeds = await feedListPendentService.execute(params);
+
+    expect(feeds).toEqual(result);
+  });
+
+  it("should return a list of feeds", async () => {
+    const mockFeeds = {
+      total: 2,
+      page: 1,
+      pageSize: 10,
+      data: [
+        {
+          id: "1",
+          title: "title",
+          image: "http://localhost:3000/image.png",
+          content: "content",
+          created_at: "2024-06-25T14:05:07.627Z",
+          is_pendent: true,
+          user_id: "1",
+        },
+        {
+          id: "2",
+          title: "title",
+          image: "http://localhost:3000/image2.png",
+          content: "content2",
+          created_at: "2024-06-25T14:05:07.627Z",
+          is_pendent: false,
+          user_id: "2",
+        },
+      ],
+    };
+
+    feedRepository.getFeedIsPendentByCompanyId.mockResolvedValue(mockFeeds.data);
+    feedRepository.getTotalFeedsIsPendentByCompanyId.mockResolvedValue([
+      { count: 2 },
+    ]);
+
+    feedListPendentService = new FeedListPendentService(feedRepository);
+
+    const feeds = await feedListPendentService.execute(params);
+
+    expect(feeds).toEqual(mockFeeds);
+  });
+});

--- a/src/useCases/UserInviteService.js
+++ b/src/useCases/UserInviteService.js
@@ -4,7 +4,7 @@ const UserRepository = require("../repository/UserRepository");
 const BussinesError = require("../errors/BussinesError");
 const MailProvider = require("../adapters/implementations/mailer/MailProvider");
 const mailProvider = new MailProvider();
-const { MEMBER, ADMIN } = require("../utils/roleUtil");
+const { MEMBER, ADMIN } = require("../utils/RoleUtil");
 const userRepository = new UserRepository();
 
 class UserInviteService {


### PR DESCRIPTION
## Describe

- Add knex query to search pending Feed by ADMIN company
- Add knex query to return total Feeds
- Endpoint Creation to list pending feeds with query srtings that determine the data limit per page
- Creation of service for listing and unit test to endpoint

## Instructions to test feature

- Run the unit test.
- `npm test`
- route to request `feeds/pending?page=1&pageSize=10`
- `npm start` to start server
