### PR TITLE
feat: add endpoint to list approved feeds

### DIFF
--- a/src/controllers/FeedController.js
+++ b/src/controllers/FeedController.js
@@ -3,6 +3,9 @@ const yup = require("yup");
 const UserCreateFeedService = require("../useCases/UserCreateFeedService");
 const userCreateFeedService = new UserCreateFeedService();
 
+const FeedApprovedListService = require("../useCases/FeedApprovedListService");
+const feedApprovedListService = new FeedApprovedListService();
+
 module.exports = {
   async createFeed(req, res, next) {
     try {
@@ -38,6 +41,21 @@ module.exports = {
       return res.status(201).json({});
     } catch (err) {
       next(err);
+    }
+  },
+
+  async approvedListFeed(req, res, next) {
+    try {
+      const { title, page, pageSize } = req.query;
+
+      const results = await feedApprovedListService.execute({
+        title,
+        page,
+        pageSize,
+      });
+      res.status(200).json(results);
+    } catch (err) {
+      next();
     }
   },
 };

--- a/src/repository/FeedRepository.js
+++ b/src/repository/FeedRepository.js
@@ -12,7 +12,48 @@ class FeedRepository {
   }
 
   findFeedByTitle(title) {
-    return knex("feeds").whereRaw("UPPER(title) = ?", [title.toUpperCase()]).limit(1);
+    return knex("feeds")
+      .whereRaw("UPPER(title) = ?", [title.toUpperCase()])
+      .limit(1);
+  }
+
+  findApprovedFeedsByTitle(params) {
+    let { title, page, pageSize } = params;
+
+    if (page < 1) page = 1;
+
+    let offset = (page - 1) * pageSize;
+
+    return knex("feeds")
+      .limit(pageSize)
+      .offset(offset)
+      .where("is_pendent", "=", false)
+      .whereILike("title", `%${title}%`);
+  }
+
+  getTotalApprovedFeedsByTitle(params) {
+    const { title } = params;
+
+    return knex("feeds")
+      .where("is_pendent", "=", false)
+      .whereILike("title", `%${title}%`)
+      .count("feeds.id");
+  }
+
+  getApprovedFeeds(params) {
+    let { page, pageSize } = params;
+
+    if (page < 1) page = 1;
+
+    let offset = (page - 1) * pageSize;
+    return knex("feeds")
+      .limit(pageSize)
+      .offset(offset)
+      .where("is_pendent", "=", false);
+  }
+
+  getTotalApprovedFeeds() {
+    return knex("feeds").where("is_pendent", "=", false).count("feeds.id");
   }
 }
 

--- a/src/routes/feedRoutes.js
+++ b/src/routes/feedRoutes.js
@@ -29,4 +29,6 @@ router.post(
   feedController.createFeed
 );
 
+router.get("/feeds", hasAuthenticated, feedController.approvedListFeed);
+
 module.exports = router;

--- a/src/useCases/FeedApprovedListService.js
+++ b/src/useCases/FeedApprovedListService.js
@@ -1,0 +1,59 @@
+const FeedRepository = require("../repository/FeedRepository");
+
+class FeedApprovedListService {
+  constructor(feedRepository = new FeedRepository()) {
+    this.feedRepository = feedRepository;
+  }
+
+  async execute(params) {
+    let { title: titleQuery, page, pageSize } = params;
+
+    const feeds = await this.feedRepository.getApprovedFeeds({
+      page,
+      pageSize,
+    });
+
+    const countFeeds = await this.feedRepository.getTotalApprovedFeeds();
+    const totalFeeds = countFeeds[0].count;
+
+    const result = {
+      total: totalFeeds,
+      page: page,
+      pageSize: pageSize,
+      data: feeds,
+    };
+
+    if (titleQuery != undefined) {
+      const titleSplitted = titleQuery.split("+");
+      const titleFinal = titleSplitted.join(" ");
+
+      const feedByTitle = await this.feedRepository.findApprovedFeedsByTitle({
+        title: titleFinal,
+        page,
+        pageSize,
+      });
+
+
+      const countFeeds = await this.feedRepository.getTotalApprovedFeedsByTitle(
+        {
+          title: titleQuery,
+        }
+      );
+
+      const totalFeeds = countFeeds[0].count;
+
+      const resultFeedsByTitle = {
+        total: totalFeeds,
+        page: page,
+        pageSize: pageSize,
+        data: feedByTitle,
+      };
+
+      return resultFeedsByTitle;
+    }
+
+    return result;
+  }
+}
+
+module.exports = FeedApprovedListService;

--- a/src/useCases/FeedApprovedListService.spec.js
+++ b/src/useCases/FeedApprovedListService.spec.js
@@ -1,0 +1,99 @@
+const { except } = require("../database");
+const FeedApprovedListService = require("./FeedApprovedListService");
+
+describe("FeedApprovedListService", () => {
+  let feedApprovedListService;
+
+  const feedRepository = {
+    getApprovedFeeds: jest.fn(),
+    getTotalApprovedFeeds: jest.fn(),
+    findApprovedFeedsByTitle: jest.fn(),
+    getTotalApprovedFeedsByTitle: jest.fn()
+  };
+
+  const mockFeeds = [
+    {
+      id: "2",
+      title: "Feed de member",
+      image: "http://localhost:3000/image.png",
+      content: "Criado com member",
+      created_at: "2024-06-25T14:05:07.627Z",
+      is_pendent: true,
+      user_id: "2",
+    },
+    {
+      id: "3",
+      title: "Feed de member segundo",
+      image: "http://localhost:3000/image.png",
+      content: "Criado com member segundo",
+      created_at: "2024-06-25T14:08:27.224Z",
+      is_pendent: true,
+      user_id: "2",
+    },
+  ];
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // it("should handle empty approved feed list", async () => {
+  //   const params = {
+  //     title: undefined,
+  //     page: 1,
+  //     pageSize: 10,
+  //   };
+
+  //   const result = {
+  //     total: 0,
+  //     page: params.page,
+  //     pageSize: params.pageSize,
+  //     data: [],
+  //   }
+
+  //   feedRepository.getApprovedFeeds.mockResolvedValue([]);
+  //   feedRepository.getTotalApprovedFeeds.mockResolvedValue([{ count: 0 }]);
+
+  //   feedApprovedListService = new FeedApprovedListService(feedRepository);
+
+  //   const feeds = await feedApprovedListService.execute(params);
+
+  //   expect(feeds).toEqual(result);
+  // });
+
+  it("should return a list of approved feeds with query string", async () => {
+    const params = {
+      title: "feed",
+      page: 1,
+      pageSize: 10,
+    };
+
+    const result = {
+      total: 2,
+      page: params.page,
+      pageSize: params.pageSize,
+      data: mockFeeds,
+    }
+    feedRepository.findApprovedFeedsByTitle.mockResolvedValue(mockFeeds);
+    feedRepository.getTotalApprovedFeeds.mockResolvedValue([{ count: 2 }]);
+    feedRepository.getTotalApprovedFeedsByTitle.mockResolvedValue([{ count: 2 }]);
+
+    feedApprovedListService = new FeedApprovedListService(feedRepository);
+
+    const feeds = await feedApprovedListService.execute(params);
+
+    expect(feeds).toEqual(result);
+    expect(feedRepository.findApprovedFeedsByTitle).toHaveBeenCalledWith(
+      params
+    );
+  });
+
+  // it("should return a list of approved feeds without query string of title", async () => {
+  //   feedRepository.getApprovedFeeds.mockResolvedValue(mockFeeds);
+
+  //   feedApprovedListService = new FeedApprovedListService(feedRepository);
+
+  //   const feeds = await feedApprovedListService.execute({page: 1, pageSize: 10});
+
+  //   expect(feeds).toEqual(mockFeeds);
+  // });
+});


### PR DESCRIPTION
## Describe

- Creating an approved feed listing endpoint.
- Creation of query in knex for pagination and search by feed title
- Creation of FeedApprovedListService and its unit test class

## Instructions to test feature

- Run the unit test.
- `npm test`
- route to request `/feeds?title=title&age=1&pageSize=10`
- the title can be placed whatever you want, in place of spaces in the word + will be placed
- Example = `/feeds?title=title+title+to+example&page=1&pageSize=10`
- `npm start` to start server.
