### PR TITLE
feat: creating an endpoint for approving pending feeds

### DIFF
--- a/src/controllers/FeedController.js
+++ b/src/controllers/FeedController.js
@@ -12,6 +12,9 @@ const feedListPendentService = new FeedListPendentService();
 const GetFeedByIdService = require("../useCases/GetFeedByIdService");
 const getFeedByIdService = new GetFeedByIdService();
 
+const ApproveFeedService = require("../useCases/ApproveFeedService");
+const approveFeedService = new ApproveFeedService();
+
 module.exports = {
   async createFeed(req, res, next) {
     try {
@@ -46,7 +49,7 @@ module.exports = {
 
       return res.status(201).json({});
     } catch (err) {
-      next(err);
+      return next(err);
     }
   },
 
@@ -59,9 +62,9 @@ module.exports = {
         page,
         pageSize,
       });
-      res.status(200).json(results);
+      return res.status(200).json(results);
     } catch (err) {
-      next(err);
+      return next(err);
     }
   },
 
@@ -77,9 +80,9 @@ module.exports = {
         pageSize,
       });
 
-      res.json(results);
+      return res.json(results);
     } catch (err) {
-      next(err);
+      return next(err);
     }
   },
 
@@ -89,9 +92,23 @@ module.exports = {
 
       const result = await getFeedByIdService.execute({ id });
 
-      res.status(200).json(result);
+      return res.status(200).json(result);
     } catch (err) {
-      next(err);
+      return next(err);
+    }
+  },
+
+  async approveFeeds(req, res, next) {
+    try {
+      const { id } = req.params;
+
+      const { is_pendent } = req.body;
+
+      const result = await approveFeedService.execute({ id, is_pendent });
+
+      return res.status(201).json(result);
+    } catch (err) {
+      return next(err);
     }
   },
 };

--- a/src/repository/FeedRepository.js
+++ b/src/repository/FeedRepository.js
@@ -77,6 +77,13 @@ class FeedRepository {
   getFeedById(id) {
     return knex("feeds").where("id", id).limit(1);
   }
+
+  updateIsPendentByIdAndIsPendent(id, is_pendent) {
+    return knex("feeds")
+      .where("id", "=", id)
+      .update({ is_pendent: is_pendent })
+      .returning("*");
+  }
 }
 
 module.exports = FeedRepository;

--- a/src/routes/feedRoutes.js
+++ b/src/routes/feedRoutes.js
@@ -39,6 +39,13 @@ router.get(
   feedController.listFeedPendent
 );
 
-router.get("/feeds/:id", feedController.getFeedById)
+router.get("/feeds/:id", feedController.getFeedById);
+
+router.put(
+  "/feeds/approve/:id",
+  hasAuthenticated,
+  authorizeRole("ADMIN"),
+  feedController.approveFeeds
+);
 
 module.exports = router;

--- a/src/useCases/ApproveFeedService.js
+++ b/src/useCases/ApproveFeedService.js
@@ -1,0 +1,29 @@
+const NotFoundError = require("../errors/NotFoundError");
+const FeedRepository = require("../repository/FeedRepository");
+
+class ApproveFeedService {
+  constructor(feedRepository = new FeedRepository()) {
+    this.feedRepository = feedRepository;
+  }
+
+  async execute(params) {
+    const { id, is_pendent } = params;
+
+    let feedById = await this.feedRepository.getFeedById(id);
+
+    console.log(feedById[0]);
+
+    if (feedById.length == 0) {
+      throw new NotFoundError("Feed inexistente.");
+    }
+
+    const result = await this.feedRepository.updateIsPendentByIdAndIsPendent(
+      id,
+      is_pendent
+    );
+
+    return result;
+  }
+}
+
+module.exports = ApproveFeedService;

--- a/src/useCases/ApproveFeedService.spec.js
+++ b/src/useCases/ApproveFeedService.spec.js
@@ -1,0 +1,73 @@
+const ApproveFeedService = require("./ApproveFeedService");
+
+describe("ApproveFeedService", () => {
+  let approveFeedService;
+
+  const feedRepository = {
+    getFeedById: jest.fn(),
+    updateIsPendentByIdAndIsPendent: jest.fn(),
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockFeed = [
+    {
+      id: "1",
+      title: "Feed de member",
+      image: "http://localhost:3000/image.png",
+      content: "Criado com member",
+      created_at: "2024-06-25T14:05:07.627Z",
+      is_pendent: true,
+      user_id: "1",
+    },
+  ];
+
+  it("Should to throw NotFoundError if not exist feed to approve", async () => {
+    try {
+      const params = {
+        id: 1,
+        is_pendent: false,
+      };
+
+      feedRepository.getFeedById.mockResolvedValue([]);
+
+      approveFeedService = new ApproveFeedService(feedRepository);
+
+      await approveFeedService.execute(params);
+    } catch (err) {
+      expect(err.message).toEqual("Feed inexistente.");
+    }
+  });
+
+  it("Should return feed by id", async () => {
+    const params = {
+      id: 1,
+      is_pendent: false,
+    };
+
+    const fakeMockFeed = [
+      {
+        id: "1",
+        title: "Feed de member",
+        image: "http://localhost:3000/image.png",
+        content: "Criado com member",
+        created_at: "2024-06-25T14:05:07.627Z",
+        is_pendent: false,
+        user_id: "1",
+      },
+    ];
+
+    feedRepository.getFeedById.mockResolvedValue(mockFeed);
+    feedRepository.updateIsPendentByIdAndIsPendent.mockResolvedValue(
+      fakeMockFeed
+    );
+
+    approveFeedService = new ApproveFeedService(feedRepository);
+
+    const result = await approveFeedService.execute(params);
+
+    expect(result).toEqual(fakeMockFeed);
+  });
+});


### PR DESCRIPTION
## Describe

- Creating endpoint to approve feed by id
- Creating query in FeedRepository to update is_pendent feed by id and is_pendent value the request body
- Creating ApproveFeedService and your unit test

## Instructions to test feature

- Run the unit test.
- `npm test`
- route to request `feeds/approve/:id`
- example of route = `localhost:3000/feeds/approve/1`
- `npm start` to start server
